### PR TITLE
chore: update biowc-spectrum to 0.0.3

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,7 +7,7 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
-        "biowc-spectrum": "^0.0.2",
+        "biowc-spectrum": "^0.0.3",
         "biowclib-mz": "^0.0.2",
         "lodash": "^4.17.21",
         "rapidoc": "^9.3.4"
@@ -4048,9 +4048,9 @@
       }
     },
     "node_modules/biowc-spectrum": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/biowc-spectrum/-/biowc-spectrum-0.0.2.tgz",
-      "integrity": "sha512-RXoSwocyFLlnTsLSBYT0aj0HrRRkgnahZchMDPkWkHw4Isz0m0vku6E9glXtU9eQ2gg2CBWztRXljo3CBegYpA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/biowc-spectrum/-/biowc-spectrum-0.0.3.tgz",
+      "integrity": "sha512-ympOXC176XsGZ+PDrMXfpBOK48tIHEe6xGR736G94UdS03CVkzN39SxBE3y9gwfSguPR82Dc14WiM1ZWi6IHVQ==",
       "dependencies": {
         "@open-wc/scoped-elements": "^3.0.5",
         "@webcomponents/scoped-custom-element-registry": "^0.0.9",

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "vue-eslint-parser": "^9.3.0"
   },
   "dependencies": {
-    "biowc-spectrum": "^0.0.2",
+    "biowc-spectrum": "^0.0.3",
     "biowclib-mz": "^0.0.2",
     "lodash": "^4.17.21",
     "rapidoc": "^9.3.4"


### PR DESCRIPTION
this brings in the quick fix in biowc-spectrum quick fix which strips
modifications from the peptide string