### PR TITLE
fix find_model_paths

### DIFF
--- a/models/start.py
+++ b/models/start.py
@@ -29,7 +29,7 @@ def find_model_dependency_loc(loc: PosixPath) -> Set[PosixPath]:
 
 def find_model_paths(pattern: str) -> List[PosixPath]:
     if type(pattern) is str:
-        return set([Path(x) for x in glob(f"[!repo]**/{pattern}")])
+        return set([Path(x) for x in glob(f"**/{pattern}") if x[:4] != "repo"])
     elif type(pattern) is PosixPath:
         return set([pattern])
     else:


### PR DESCRIPTION
The way the models paths were searched for caused every path starting with "r" "e" "p" "o" to be excluded. This fix performs the exclusion of repo/ by an if statement in the list comprehension. 