### PR TITLE
Replacing the trigger to pull_request_target

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,7 @@ name: Publish Python client package to PyPI
 permissions: write-all
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: closed

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,7 +1,7 @@
 name: Create a tag and publish a Docker image
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     types: closed


### PR DESCRIPTION
This should resolve the forced read-only access for GITHUB_TOKEN when triggered from public forks.