### PR TITLE
Changed peptide dtype encoding from U46 to U100.

### DIFF
--- a/models/MultiFrag/Prosit_2025_intensity_MultiFrag/1/model.py
+++ b/models/MultiFrag/Prosit_2025_intensity_MultiFrag/1/model.py
@@ -90,7 +90,7 @@ class TritonPythonModel:
                 pb_utils.get_input_tensor_by_name(request, "peptide_sequences")
                 .as_numpy()
                 .flatten()
-            ).astype('U46') # binary (b'word') to string ('word')
+            ).astype('U100') # binary (b'word') to string ('word')
             charge_in = (
                 pb_utils.get_input_tensor_by_name(request, "precursor_charges")
                 .as_numpy()


### PR DESCRIPTION
Didn't work for very long sequences. Changed the numpy string encoding from U46 to U100. Should work now.