### PR TITLE
Increased maximum peptide sequence string length to 200 characters.

### DIFF
--- a/models/MultiFrag/Prosit_2025_intensity_MultiFrag/1/model.py
+++ b/models/MultiFrag/Prosit_2025_intensity_MultiFrag/1/model.py
@@ -90,7 +90,7 @@ class TritonPythonModel:
                 pb_utils.get_input_tensor_by_name(request, "peptide_sequences")
                 .as_numpy()
                 .flatten()
-            ).astype('U100') # binary (b'word') to string ('word')
+            ).astype('U200') # binary (b'word') to string ('word')
             charge_in = (
                 pb_utils.get_input_tensor_by_name(request, "precursor_charges")
                 .as_numpy()


### PR DESCRIPTION
Trying to prevent any future errors for peptide sequences that contain many modifications and thus have very long string representations.