### PR TITLE
ci: upgrade upload-artifact and download-artifact to v4

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build using poetry
       run: cd clients/python && poetry build
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: clients/python/dist/
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
## Problem
GitHub Actions deprecated `actions/upload-artifact@v3` and `actions/download-artifact@v3`, causing post-merge execution of `publish-to-pypi.yml` to fail with:
> `This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3.`

## Solution
- Upgraded `actions/upload-artifact` from `v3` to `v4`
- Upgraded `actions/download-artifact` from `v3` to `v4`

This unblocks PyPI automated publishing for `koinapy` releases.
