### PR TITLE
ci: upgrade upload-artifact and download-artifact to v4

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,14 +2,15 @@ name: Publish Python client package to PyPI
 permissions: write-all
 
 on:
-  pull_request_target:
+  push:
     branches:
       - main
-    types: closed
+    paths:
+      - 'clients/python/pyproject.toml'
+  workflow_dispatch:
 
 jobs:
   build:
-    if: ${{ github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'python-client') }} 
     name: Build package
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Problem
The PyPI release workflow failed on merge with two errors:
1. **PyPI Trusted Publishing Failure**: PyPI's trusted publisher policy rejects `pull_request_target` event triggers (`invalid-publisher: Publishing from a workflow invoked via 'pull_request_target' is not supported.`).
2. **Artifact Action Deprecation**: `actions/upload-artifact@v3` and `actions/download-artifact@v3` were deprecated and rejected by GitHub.

## Solution
- Changed workflow trigger in `publish-to-pypi.yml` to `push` on `main` for changes to `clients/python/pyproject.toml` (which PyPI Trusted Publishing requires and supports).
- Added `workflow_dispatch` trigger so PyPI releases can also be manually dispatched from the GitHub UI when needed.
- Upgraded `actions/upload-artifact` and `actions/download-artifact` from `v3` to `v4`.
